### PR TITLE
Update Searcher.java

### DIFF
--- a/mica-ip2region/src/main/java/net/dreamlu/mica/ip2region/core/Searcher.java
+++ b/mica-ip2region/src/main/java/net/dreamlu/mica/ip2region/core/Searcher.java
@@ -6,6 +6,7 @@ package net.dreamlu.mica.ip2region.core;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 
 /**
  * xdb searcher (Not thread safe implementation)
@@ -128,7 +129,7 @@ public class Searcher {
 		// load and return the region data
 		final byte[] regionBuff = new byte[dataLen];
 		read(dataPtr, regionBuff);
-		return new String(regionBuff);
+		return new String(regionBuff, StandardCharsets.UTF_8);
 	}
 
 	protected void read(int offset, byte[] buffer) throws IOException {


### PR DESCRIPTION
默认使用 UTF-8 的字符集，解决云服务器解析IP地理信息乱码������ ���������问题。

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix（bug修复）


**The description of the PR（PR描述）:**
解决云服务器解析IP地理信息乱码������ ���������问题。

**Other information（其他信息）:**