### PR TITLE
:bug: fix mica-ip2region ipv6数据库文件AOT支持

### DIFF
--- a/mica-ip2region/src/main/java/net/dreamlu/mica/ip2region/config/Ip2regionRuntimeHintsRegistrar.java
+++ b/mica-ip2region/src/main/java/net/dreamlu/mica/ip2region/config/Ip2regionRuntimeHintsRegistrar.java
@@ -28,7 +28,9 @@ class Ip2regionRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
 
 	@Override
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-		hints.resources().registerPattern("ip2region/ip2region.xdb");
+		// matches all the files in "ip2region" directory where is under resource directory
+		// and its child directories at any depth
+		hints.resources().registerPattern("ip2region/*");
 	}
 
 }


### PR DESCRIPTION
**注意：github 上的少，可能响应不够及时，建议 gitee 上发起**

**What kind of change does this PR introduce?** (check at least one)

- [√] Bugfix（bug修复）
- [ ] Feature（新功能）
- [ ] Code style update（代码格式调整）
- [ ] Refactor（重构）
- [ ] Build-related changes（与构建相关的更改）
- [ ] Other, please describe（其他，请说明）:


**The description of the PR（PR描述）:**
AOT之前没有扫描到ipv6wry.db文件，就调整了一下hint规则

**Other information（其他信息）:**
